### PR TITLE
Tile item styling fixes

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -149,7 +149,8 @@
           gap: 5px;
           border: 1px solid #D1D1D1;
           border-radius: 10px;
-          padding: 4px;
+          padding: 4px 8px 4px 4px;
+          cursor: pointer;
 
           div {
             width: 21px;
@@ -160,7 +161,11 @@
           }
 
           span {
+            flex: 1;
             font-size: 12px;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
           }
         }
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,6 +25,7 @@ export function createTilesNode(tiles) {
     title.innerHTML = tileData.report_name;
 
     const tileNode = createNode("tile-item");
+    tileNode.title = tileData.report_name;
     tileNode.onclick = () => window.open(tileData.url, '_blank').focus();
     tileNode.appendChild(imageContainer);
     tileNode.appendChild(title);


### PR DESCRIPTION
- Set `pointer` cursor on tile items
- Used ellipsis on report name overflows in tile items
- Added full report name as tooltip in tile items