### PR TITLE
Handle Error in JSON format.

### DIFF
--- a/dev/init.js
+++ b/dev/init.js
@@ -53,7 +53,17 @@ const creatSubmitHandlerMethod = (sessionId) => {
       }
 
       if (errorMsg) {
-        return Promise.resolve([{ type: "text", message: errorMsg }]);
+        try {
+          const parsedError = JSON.parse(errorMsg);
+          return Promise.resolve([
+            {
+              type: "text",
+              message: "Something went wrong. Please try again later.",
+            },
+          ]);
+        } catch {
+          return Promise.resolve([{ type: "text", message: errorMsg }]);
+        }
       }
       if (!response.ok) {
         return Promise.resolve(response.json());


### PR DESCRIPTION
In the case of status code 400, the 500 backend gives an error in JSON format. We show a generic error to the user in both cases.